### PR TITLE
Adding logstash to populate metadata

### DIFF
--- a/docker/examples/elastic/docker-compose-local.yml
+++ b/docker/examples/elastic/docker-compose-local.yml
@@ -85,6 +85,19 @@ services:
       ELASTICSEARCH_HOSTS: '["http://elastic:9200"]'
       SERVER_BASEPATH: /dashboard
 
+  logstash:
+    build: ./logstash
+    container_name: logstash
+    environment:
+      ELASTICSEARCH_URL: http://elastic:9200
+      ELASTICSEARCH_HOSTS: '["http://elastic:9200"]'
+      XPACK_MONITORING_ENABLED: 'false'
+      DATASET: 'masked'
+    links:
+      - elastic_search
+    depends_on:
+      - elastic_search
+
 volumes:
   elastic_search_data: {}
 

--- a/docker/examples/elastic/docker-compose.yml
+++ b/docker/examples/elastic/docker-compose.yml
@@ -109,6 +109,19 @@ services:
     depends_on:
       - pygeoapi
 
+  logstash:
+    build: ./logstash
+    container_name: logstash
+    environment:
+      ELASTICSEARCH_URL: http://elastic:9200
+      ELASTICSEARCH_HOSTS: '["http://elastic:9200"]'
+      XPACK_MONITORING_ENABLED: 'false'
+      DATASET: 'masked'
+    links:
+      - elastic_search
+    depends_on:
+      - elastic_search
+
 
 volumes:
   elastic_search_data: {}

--- a/docker/examples/elastic/logstash/Dockerfile
+++ b/docker/examples/elastic/logstash/Dockerfile
@@ -1,0 +1,5 @@
+FROM docker.elastic.co/logstash/logstash:7.5.1
+
+LABEL maintainer="ant@byteroad.net"
+
+COPY masked_metadata.conf  /usr/share/logstash/pipeline/masked_metadata.conf

--- a/docker/examples/elastic/logstash/masked_metadata.conf
+++ b/docker/examples/elastic/logstash/masked_metadata.conf
@@ -1,0 +1,74 @@
+# Connection to Elasticsearch
+input {
+        elasticsearch {
+                hosts => ["elastic:9200"]
+                #user => "elastic"
+                #password => "elastic12pr2"
+                index => "masked"
+                #ilm_enabled => false
+                #manage_template => false
+                #document_id => "%{_id}"
+                #doc_as_upsert => true
+        }
+}
+# Data transformation
+filter {
+        kv {
+                id => "add_metadata"
+                add_field => [ "[properties][recordCreated]", "%{@timestamp}",
+                                "[properties][recordUpdated]", "%{@timestamp}",
+                                "[properties][created]", "%{@timestamp}",
+                                "[properties][updated]", "%{@timestamp}",
+                                "[properties][associations][href]", "https://emotional.byteroad.net/collections/masked/items/%{[properties][fid]}?f=json"]
+                default_keys => [ "[properties][type]", "dataset",
+                                "[properties][title]", "Example test data",
+                                "[properties][description]", "Example measurements around the city of Lisbon",
+                                "[properties][keywords]", "experiment",
+                                "[properties][keywords]", "temperature",
+                                "[properties][language]", "en",
+                                "[properties][publisher]", "https://byteroad.net/",
+                                "[properties][formats]", "CSV",
+                                "[properties][formats]", "GeoJSON",
+                                "[properties][contactPoint]", "Byte Road",
+                                "[properties][associations][rel]", "item",
+                                "[properties][associations][title]", "Link to the item",
+                                "[properties][associations][type]", "application/geo+json"]
+        }
+        mutate {
+                id => "remove_features"
+                remove_field => [ "[properties][datetime]",
+                                "[properties][speed_meters_per_hour]",
+                                "[properties][s1_Temperature_Celsius]",
+                                "[properties][decibel_dB]",
+                                "[properties][pm_concentration_pm100_micrograms_cube_meters]",
+                                "[properties][pm_concentration_pm10_micrograms_cube_meters]",
+                                "[properties][pm_concentration_pm25_micrograms_cube_meters]",
+                                "[properties][pm_count_greater03um_nan]",
+                                "[properties][pm_count_greater05um_nan]",
+                                "[properties][pm_count_greater100um_nan]",
+                                "[properties][pm_count_greater10um_nan]",
+                                "[properties][pm_count_greater25um_nan]",
+                                "[properties][pm_count_greater50um_nan]",
+                                "[properties][s2_Temperature_Celsius]",
+                                "[properties][co2_concentration_ppm]",
+                                "[properties][Humidity_percentageRH]",
+                                "[properties][s3_Temperature_Celsius]",
+                                "[properties][MRT]",
+                                "[properties][UTCI]"]
+        }
+}
+# Output to Elasticsearch
+output {
+        elasticsearch {
+                hosts => ["elastic:9200"]
+                #user => "elastic"
+                #password => "elastic12pr2"
+                index => "masked_metadata"
+                #template_overwrite => true
+                #template_name => "metadata_template"
+                ilm_enabled => false
+                manage_template => false
+                document_id => "%{[properties][fid]}"
+                doc_as_upsert => true
+        }
+}

--- a/docker/examples/elastic/pygeoapi/docker.config.local.yml
+++ b/docker/examples/elastic/pygeoapi/docker.config.local.yml
@@ -163,7 +163,7 @@ resources:
             - type: record
               name: Elasticsearch
               #Note elastic_search is the docker container of ES the name is defined in the docker-compose.yml
-              data: http://elastic_search:9200/DATASET
+              data: http://elastic_search:9200/DATASET_metadata
               id_field: fid
               time_field: datetime
 

--- a/docker/examples/elastic/pygeoapi/docker.config.yml
+++ b/docker/examples/elastic/pygeoapi/docker.config.yml
@@ -163,6 +163,6 @@ resources:
             - type: record
               name: Elasticsearch
               #Note elastic_search is the docker container of ES the name is defined in the docker-compose.yml
-              data: http://elastic_search:9200/DATASET
+              data: http://elastic_search:9200/DATASET_metadata
               id_field: fid
               time_field: datetime


### PR DESCRIPTION
Adding a Logstash to generate a new Elasticsearch index for metadata. The index will have the name of the original feature dataset, configured in the docker_compose with env variable DATASET, plus "_metadata".

The generation will start in the background and will run continuously keeping the metadata aligned with the feature collection.

The file logstash/masked_metadata.conf contains default values to generate metadata records.